### PR TITLE
feat: use per-user behavior settings in attendance controller (#452)

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -108,7 +108,7 @@ class DefaultController extends AbstractController
         }, $servicosUsuario);
 
         $servicosIndisponiveis = $servicoService->servicosIndisponiveis($unidade, $usuario);
-        $settings = $this->settingsService->loadBehaviorSettings();
+        $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
 
         return $this->render('@NovosgaAttendance/default/index.html.twig', [
             'time' => time() * 1000,
@@ -381,14 +381,14 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
-        $settings = $this->settingsService->loadBehaviorSettings();
-        if (!$settings->callTicketByService) {
-            throw new Exception('Chamar senha por serviço não é permitido');
-        }
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
+
+        $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
+        if (!$settings->callTicketByService) {
+            throw new Exception('Chamar senha por serviço não é permitido');
+        }
 
         // verifica se ja esta atendendo alguem
         $this->checkAtendimentoEmAndamento($atendimentoService, $usuario, $unidade);
@@ -444,14 +444,14 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
-        $settings = $this->settingsService->loadBehaviorSettings();
-        if (!$settings->callTicketOutOfOrder) {
-            throw new Exception('Chamar senha fora de ordem serviço não é permitido');
-        }
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
+
+        $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
+        if (!$settings->callTicketOutOfOrder) {
+            throw new Exception('Chamar senha fora de ordem serviço não é permitido');
+        }
 
         // verifica se ja esta atendendo alguem
         $this->checkAtendimentoEmAndamento($atendimentoService, $usuario, $unidade);


### PR DESCRIPTION
Issue: novosga/novosga#452

## Summary

Replace all three `loadBehaviorSettings()` calls with `loadUserBehaviorSettings($usuario)` in `DefaultController`:

- `index()` — controls which features are shown in the UI
- `chamarServico()` — enforces `callTicketByService` permission
- `chamarAtendimento()` — enforces `callTicketOutOfOrder` permission

The `$usuario` variable (`$this->getUser()`) is already available at each call site. No new injection needed — `ApplicationSettingsServiceInterface` already has the new method after the `core` interface update.

Part of #452 — see also PRs in `core`, `novosga`, and `settings-bundle`.

## Test plan

- [x] With no user override: behavior identical to before (global setting applies)
- [x] Set `callTicketByService = false` override for a user → that user cannot call by service even if global is `true`
- [x] Set `callTicketOutOfOrder = false` override → out-of-order call is blocked for that user
- [x] Reset override to `null` → user inherits global setting again

🤖 Generated with [Claude Code](https://claude.com/claude-code)