### PR TITLE
feat: enforce changeTicketType flag in attendance (#460)

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -216,7 +216,14 @@ class DefaultController extends AbstractController
         );
 
         try {
-            $tipo = ($data->tipoAtendimento ?? FilaServiceInterface::TIPO_TODOS);
+            $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
+            if ($settings->changeTicketType) {
+                $tipo = $data->tipoAtendimento;
+            } else {
+                $tipo = $usuarioService->meta($usuario, UsuarioServiceInterface::ATTR_ATENDIMENTO_TIPO)?->getValue();
+            }
+            $tipo ??= FilaServiceInterface::TIPO_TODOS;
+
             if ($data->numeroLocal <= 0) {
                 throw new Exception(
                     $this->translator->trans(

--- a/src/Resources/views/default/index.html.twig
+++ b/src/Resources/views/default/index.html.twig
@@ -424,8 +424,8 @@
                                 </div>
                                 <div class="col-sm-6">
                                     <div class="mb-3">
-                                        <label class="control-label" title="{{ 'label.attendance.type'|trans }}">{{ 'label.attendance'|trans }}</label>
-                                        <select class="form-control" v-model="novoLocal.tipoAtendimento" required>
+                                        <label class="control-label">{{ 'label.attendance.type'|trans }}</label>
+                                        <select class="form-control" v-model="novoLocal.tipoAtendimento" required :disabled="!settings.changeTicketType">
                                             {% for v,l in tiposAtendimento %}
                                                 <option value="{{ v }}" {% if tipoAtendimento == v %}selected="selected"{% endif %}>{{ l }}</option>
                                             {% endfor %}
@@ -730,6 +730,7 @@
         const atendimento = {{ atendimento|json_encode()|raw }};
         const tipoAtendimento = "{{ tipoAtendimento ? tipoAtendimento : 'null' }}";
         const tiposAtendimento = {{ tiposAtendimento|json_encode()|raw }};
+        const settings = {{ settings|json_encode()|raw }};
         const servicosUsuario = {{ servicos|json_encode()|raw }};
         const labelSim = "{{ 'label.yes'|trans }}";
         const labelNao = "{{ 'label.no'|trans }}";


### PR DESCRIPTION
## Summary

Enforces the `changeTicketType` behavior flag in the attendance module as part of novosga/novosga#460 (main PR: novosga/novosga#494).

- `setLocal()`: when `changeTicketType` is `false`, preserves the user's existing stored ticket type instead of accepting the submitted value
- `index.html.twig`: adds `const settings` JS variable; type selector gets `:disabled="!settings.changeTicketType"` in the Set Location modal

## Test plan

- [ ] `changeTicketType = false` → type dropdown is disabled; submitting a different type via `setLocal()` keeps the user's existing type
- [ ] `changeTicketType = true` (default) → type dropdown works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)