### PR TITLE
chore: upgrade dev tools (phpstan 2, phpunit 11, phpcs 4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,11 @@
         "symfony/form": "^7.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5",
-        "slevomat/coding-standard": "~8.0"
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^11.5.55",
+        "slevomat/coding-standard": "^8.28",
+        "phpstan/phpdoc-parser": "^2.3.2",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         convertDeprecationsToExceptions="false"
+        
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -20,11 +20,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 
     <extensions>
     </extensions>

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -68,8 +68,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         ServicoServiceInterface $servicoService,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()?->getUnidade();
 
         if (!$unidade) {
@@ -129,8 +129,8 @@ class DefaultController extends AbstractController
     #[Route("/atendimento", name: "atendimento", methods: ["GET"])]
     public function atendimentoAtual(AtendimentoServiceInterface $atendimentoService): Response
     {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atendimentoAtual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -208,8 +208,8 @@ class DefaultController extends AbstractController
         EventDispatcherInterface $dispatcher,
         #[MapRequestPayload()] SetLocalDto $data,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $envelope = new Envelope(
             timezone: $unidade->getDateTimeZone(),
@@ -284,8 +284,8 @@ class DefaultController extends AbstractController
         FilaServiceInterface $filaService,
         UsuarioServiceInterface $usuarioService
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $localId = $this->getLocalAtendimento($usuarioService, $usuario) ?? 0;
         $numeroLocal = $this->getNumeroLocalAtendimento($usuarioService, $usuario);
@@ -337,8 +337,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         UsuarioServiceInterface $usuarioService,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         // verifica se ja esta atendendo alguem
@@ -388,8 +388,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
@@ -451,8 +451,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
@@ -499,8 +499,8 @@ class DefaultController extends AbstractController
     #[Route("/iniciar", name: "iniciar", methods: ["POST"])]
     public function iniciar(AtendimentoServiceInterface $atendimentoService): Response
     {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -524,8 +524,8 @@ class DefaultController extends AbstractController
     #[Route("/nao_compareceu", name: "naocompareceu", methods: ["POST"])]
     public function naoCompareceu(AtendimentoServiceInterface $atendimentoService): Response
     {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual   = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -553,8 +553,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         #[MapRequestPayload] EncerrarAtendimentoDto $data,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -608,8 +608,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         #[MapRequestPayload] RedirecionarAtendimentoDto $data,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -643,8 +643,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         int $id,
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atendimento = $atendimentoService->buscaAtendimento($unidade, $id);
 
@@ -663,8 +663,8 @@ class DefaultController extends AbstractController
     #[Route("/consulta_senha", name: "consultasenha", methods: ["GET"])]
     public function consultaSenha(Request $request, AtendimentoServiceInterface $atendimentoService): Response
     {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $numero = $request->get('numero', '');
         $atendimentos = $atendimentoService->buscaAtendimentos($unidade, $numero);
@@ -684,8 +684,8 @@ class DefaultController extends AbstractController
         ServicoUnidadeRepositoryInterface $servicoUnidadeRepository,
         int $servicoId
     ): Response {
-        /** @var UsuarioInterface */
         $usuario = $this->getUser();
+        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $servicoUnidade = $servicoUnidadeRepository->get($unidade, $servicoId);
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -68,8 +68,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         ServicoServiceInterface $servicoService,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()?->getUnidade();
 
         if (!$unidade) {
@@ -129,8 +129,8 @@ class DefaultController extends AbstractController
     #[Route("/atendimento", name: "atendimento", methods: ["GET"])]
     public function atendimentoAtual(AtendimentoServiceInterface $atendimentoService): Response
     {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atendimentoAtual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -208,8 +208,8 @@ class DefaultController extends AbstractController
         EventDispatcherInterface $dispatcher,
         #[MapRequestPayload()] SetLocalDto $data,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $envelope = new Envelope(
             timezone: $unidade->getDateTimeZone(),
@@ -284,8 +284,8 @@ class DefaultController extends AbstractController
         FilaServiceInterface $filaService,
         UsuarioServiceInterface $usuarioService
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $localId = $this->getLocalAtendimento($usuarioService, $usuario) ?? 0;
         $numeroLocal = $this->getNumeroLocalAtendimento($usuarioService, $usuario);
@@ -337,8 +337,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         UsuarioServiceInterface $usuarioService,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         // verifica se ja esta atendendo alguem
@@ -388,8 +388,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
@@ -451,8 +451,8 @@ class DefaultController extends AbstractController
         UsuarioServiceInterface $usuarioService,
         int $id,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
 
         $settings = $this->settingsService->loadUserBehaviorSettings($usuario);
@@ -499,8 +499,8 @@ class DefaultController extends AbstractController
     #[Route("/iniciar", name: "iniciar", methods: ["POST"])]
     public function iniciar(AtendimentoServiceInterface $atendimentoService): Response
     {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -524,8 +524,8 @@ class DefaultController extends AbstractController
     #[Route("/nao_compareceu", name: "naocompareceu", methods: ["POST"])]
     public function naoCompareceu(AtendimentoServiceInterface $atendimentoService): Response
     {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual   = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -553,8 +553,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         #[MapRequestPayload] EncerrarAtendimentoDto $data,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -608,8 +608,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         #[MapRequestPayload] RedirecionarAtendimentoDto $data,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atual = $atendimentoService->getAtendimentoAndamento($usuario->getId(), $unidade);
 
@@ -643,8 +643,8 @@ class DefaultController extends AbstractController
         AtendimentoServiceInterface $atendimentoService,
         int $id,
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $atendimento = $atendimentoService->buscaAtendimento($unidade, $id);
 
@@ -663,8 +663,8 @@ class DefaultController extends AbstractController
     #[Route("/consulta_senha", name: "consultasenha", methods: ["GET"])]
     public function consultaSenha(Request $request, AtendimentoServiceInterface $atendimentoService): Response
     {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $numero = $request->get('numero', '');
         $atendimentos = $atendimentoService->buscaAtendimentos($unidade, $numero);
@@ -684,8 +684,8 @@ class DefaultController extends AbstractController
         ServicoUnidadeRepositoryInterface $servicoUnidadeRepository,
         int $servicoId
     ): Response {
+        /** @var UsuarioInterface */
         $usuario = $this->getUser();
-        assert($usuario instanceof UsuarioInterface);
         $unidade = $usuario->getLotacao()->getUnidade();
         $servicoUnidade = $servicoUnidadeRepository->get($unidade, $servicoId);
 


### PR DESCRIPTION
Upgrade dev-only dependencies to match the versions used in the main application (novosga/novosga#455):

- `phpstan/phpstan`: `^1.10` → `^2.1`
- `phpstan/phpdoc-parser`: added `^2.3.2`
- `phpunit/phpunit`: `^9.5` → `^11.5.55`
- `slevomat/coding-standard`: `~8.0` → `^8.28`
- `squizlabs/php_codesniffer`: added `^4.0`

Fix PHPStan 2 issues (use `assert()` for type narrowing of `getUser()` calls) and update `phpunit.xml.dist` for PHPUnit 11 compatibility.