### PR TITLE
Adiciona configuração para exibir nome do cliente na fila de ticket

### DIFF
--- a/src/Resources/public/js/script.js
+++ b/src/Resources/public/js/script.js
@@ -41,6 +41,9 @@
             customerModal: null,
             senhaModal: null,
             localModal: null,
+            config: {
+                exibirNomeCliente: false
+            },
         },
         methods: {
             update() {
@@ -397,6 +400,25 @@
                     alert('Erro ao salvar cliente');
                     submitButton.disabled = false;
                 });
+            },
+
+            saveConfig() {
+                App.Storage.set('novosga.attendance', JSON.stringify(this.config));
+            },
+
+            loadConfig() {
+                try {
+                    const json = App.Storage.get('novosga.attendance');
+                    const config = (JSON.parse(json) || {});
+
+                    if (config.exibirNomeCliente === undefined) {
+                        config.exibirNomeCliente = false;
+                    }
+
+                    this.config.exibirNomeCliente = config.exibirNomeCliente;
+                } catch (e) {
+                    // do nothing
+                }
             }
         },
         mounted() {
@@ -431,6 +453,7 @@
                 this.update();
             };
             
+            this.loadConfig();
             this.update();
 
             if (!local) {

--- a/src/Resources/public/js/script.js
+++ b/src/Resources/public/js/script.js
@@ -42,7 +42,7 @@
             senhaModal: null,
             localModal: null,
             config: {
-                exibirNomeCliente: false
+                formatoExibicaoFila: null
             },
         },
         methods: {
@@ -363,6 +363,23 @@
                 return styles.join(';')
             },
 
+            getAtendimentoLabel(atendimento) {
+                const formato = this.config.formatoExibicaoFila;
+                const temCliente = !!atendimento.cliente;
+                const senha = atendimento.senha.format;
+                const nome = temCliente ? atendimento.cliente.nome : '';
+
+                if (formato === 'client_name' && temCliente) {
+                    return nome;
+                }
+
+                if (formato === 'ticket_client_name' && temCliente) {
+                    return `${senha} - ${nome}`;
+                }
+
+                return senha;
+            },
+
             async loadCustomer() {
                 const body = this.$refs.customerModal.querySelector('.modal-body')
                 body.innerHTML = '';
@@ -411,11 +428,11 @@
                     const json = App.Storage.get('novosga.attendance');
                     const config = (JSON.parse(json) || {});
 
-                    if (config.exibirNomeCliente === undefined) {
-                        config.exibirNomeCliente = false;
+                    if (config.formatoExibicaoFila === undefined) {
+                        config.formatoExibicaoFila = 'ticket';
                     }
 
-                    this.config.exibirNomeCliente = config.exibirNomeCliente;
+                    this.config.formatoExibicaoFila = config.formatoExibicaoFila;
                 } catch (e) {
                     // do nothing
                 }

--- a/src/Resources/translations/NovosgaAttendanceBundle.en.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.en.xlf
@@ -402,6 +402,31 @@
         <source>modal.customer</source>
         <target>Edit customer</target>
       </trans-unit>
+
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuration</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Queue display format</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Ticket number</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Customer name</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Ticket number and customer name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaAttendanceBundle.en_US.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.en_US.xlf
@@ -402,6 +402,31 @@
         <source>modal.customer</source>
         <target>Edit customer</target>
       </trans-unit>
+
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuration</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Queue display format</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Ticket number</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Customer name</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Ticket number and customer name</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaAttendanceBundle.es.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.es.xlf
@@ -395,6 +395,31 @@
         <source>modal.customer</source>
         <target>Editar cliente</target>
       </trans-unit>
+
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuración</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Formato de visualización de la fila</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Número de turno</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Nombre del cliente</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Número de turno y nombre del cliente</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaAttendanceBundle.es_AR.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.es_AR.xlf
@@ -404,6 +404,31 @@
         <source>modal.customer</source>
         <target>Editar cliente</target>
       </trans-unit>
+
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuración</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Formato de visualización de la fila</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Número de turno</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Nombre del cliente</target>
+      </trans-unit>
+
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Número de turno y nombre del cliente</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaAttendanceBundle.pt_BR.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.pt_BR.xlf
@@ -330,6 +330,26 @@
         <source>label.edit_customer_info</source>
         <target>Para editar o cliente primeiro precisa iniciar o atendimento</target>
       </trans-unit>
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuração</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Formato de exibição da fila</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Número da senha</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Nome do cliente</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Número da senha e nome do cliente</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/translations/NovosgaAttendanceBundle.pt_PT.xlf
+++ b/src/Resources/translations/NovosgaAttendanceBundle.pt_PT.xlf
@@ -387,6 +387,26 @@
         <source>label.edit_customer_info</source>
         <target>Para editar o cliente primeiro precisa iniciar o atendimento</target>
       </trans-unit>
+      <trans-unit id="label.configuration">
+        <source>label.configuration</source>
+        <target>Configuração</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.select_display_format_label">
+        <source>label.configuration.select_display_format_label</source>
+        <target>Formato de exibição da fila</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_ticket">
+        <source>label.configuration.option_ticket</source>
+        <target>Número da senha</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_client_name">
+        <source>label.configuration.option_client_name</source>
+        <target>Nome do cliente</target>
+      </trans-unit>
+      <trans-unit id="label.configuration.option_ticket_client_name">
+        <source>label.configuration.option_ticket_client_name</source>
+        <target>Número da senha e nome do cliente</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/views/default/index.html.twig
+++ b/src/Resources/views/default/index.html.twig
@@ -4,6 +4,14 @@
 
 {% block body %}
     <div id="attendance" v-cloak data-base-url="{{ path('novosga_attendance_index') }}">
+        <div class="d-flex">
+            <div class="ms-auto mt-3">
+                <a href="#dialog-atendimento-config" class="btn btn-outline-secondary" data-bs-toggle="modal">
+                    <i class="fa fa-cog"></i>&nbsp;
+                    {% trans %}Configuração{% endtrans %}
+                </a>
+            </div>
+        </div>
         <div id="atendimento" v-if="usuario.numeroLocal && usuario.local">
             <div class="row">
                 <div class="col-sm-3 col-md-2">
@@ -355,7 +363,7 @@
                     </span>
                 </h5>
                 <div class="card-body">
-                    <ul>
+                    <ul v-bind:style="{ display: config.exibirNomeCliente ? 'grid' : 'inline' }">
                         <li>
                             <button class="btn btn-outline-primary"
                                 title="{{ 'button.call_next'|trans }}"
@@ -384,6 +392,7 @@
                                v-bind:title="atendimento.servico.nome + ' (' + atendimento.tempoEspera + ')'">
                                 {%- verbatim -%}
                                     {{ atendimento.senha.format }}
+                                    <span v-if="config.exibirNomeCliente && atendimento.cliente"> - {{ atendimento.cliente?.nome }}</span>
                                 {%- endverbatim -%}
                             </a>
                         </li>
@@ -704,6 +713,33 @@
                             </button>
                         </div>
                     {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {# dialog de atendimento #}
+        <div id="dialog-atendimento-config" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">{% trans %}Configuração{% endtrans %}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="row">
+                            <div class="col-sm-12">
+                                <fieldset>
+                                    <legend>{% trans %}Fila de Senhas{% endtrans %}</legend>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" v-model="config.exibirNomeCliente" v-on:change="saveConfig"> 
+                                            {% trans %}Exibir nome do cliente{% endtrans %}
+                                        </label>
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/Resources/views/default/index.html.twig
+++ b/src/Resources/views/default/index.html.twig
@@ -353,53 +353,56 @@
                     </div>
                 </div>
             </div>
-            <div v-bind:class="{'fila card mb-3':true, 'border-dark': !fila.servico}" v-for="fila in filas" v-if="!fila.servico || fila.atendimentos.length>0">
-                <h5 class="card-header">
-                    <span v-if="!fila.servico">Todos serviços</span>
-                    <span v-if="fila.servico">
-                        {% verbatim %}
-                            {{fila.servico.servico.nome}}
-                        {% endverbatim %}
-                    </span>
-                </h5>
-                <div class="card-body">
-                    <ul v-bind:style="{ display: config.exibirNomeCliente ? 'grid' : 'inline' }">
-                        <li>
-                            <button class="btn btn-outline-primary"
-                                title="{{ 'button.call_next'|trans }}"
-                                v-bind:disabled="busy || fila.atendimentos.length===0 || atendimento"
-                                v-on:click="chamar"
-                                v-if="!fila.servico">
-                                <i class="fa fa-bullhorn"></i>
-                                {{ 'button.call'|trans }}
-                            </button>
-                            {% if settings.callTicketByService %}
-                                <button class="btn btn-outline-primary"
-                                    title="{{ 'button.call_next'|trans }}"
-                                    v-bind:disabled="busy || fila.atendimentos.length===0 || atendimento"
-                                    v-on:click="chamarServico(fila.servico.servico)"
-                                    v-if="fila.servico">
-                                    <i class="fa fa-bullhorn"></i>
-                                    {{ 'button.call'|trans }}
-                                </button>
-                            {% endif %}
-                        </li>
-                        <li v-for="(atendimento, index) in fila.atendimentos">
-                            <a href="#"
-                               v-bind:class="{ prioridade: atendimento.prioridade.peso, proximo: index===0 }"
-                               v-bind:style="getItemFilaStyle(atendimento)"
-                               v-on:click.prevent="infoSenha(atendimento)"
-                               v-bind:title="atendimento.servico.nome + ' (' + atendimento.tempoEspera + ')'">
-                                {%- verbatim -%}
-                                    {{ atendimento.senha.format }}
-                                    <span v-if="config.exibirNomeCliente && atendimento.cliente"> - {{ atendimento.cliente?.nome }}</span>
-                                {%- endverbatim -%}
-                            </a>
-                        </li>
-                        <li class="empty" v-if="fila.atendimentos.length===0">
-                            {{ 'label.my_queue.empty'|trans }}
-                        </li>
-                    </ul>
+            <div class="row">
+                <div v-bind:class="{ 'col-12': true, 'col-md-6': config.formatoExibicaoFila !== 'ticket' }" v-for="fila in filas" v-if="!fila.servico || fila.atendimentos.length>0">
+                    <div v-bind:class="{'fila card mb-3':true, 'border-dark': !fila.servico}">
+                        <h5 class="card-header">
+                            <span v-if="!fila.servico">Todos serviços</span>
+                            <span v-if="fila.servico">
+                                {% verbatim %}
+                                    {{fila.servico.servico.nome}}
+                                {% endverbatim %}
+                            </span>
+                        </h5>
+                        <div class="card-body">
+                            <ul v-bind:style="{ display: config.formatoExibicaoFila !== 'ticket' ? 'grid' : 'inline' }">
+                                <li>
+                                    <button class="btn btn-outline-primary"
+                                        title="{{ 'button.call_next'|trans }}"
+                                        v-bind:disabled="busy || fila.atendimentos.length===0 || atendimento"
+                                        v-on:click="chamar"
+                                        v-if="!fila.servico">
+                                        <i class="fa fa-bullhorn"></i>
+                                        {{ 'button.call'|trans }}
+                                    </button>
+                                    {% if settings.callTicketByService %}
+                                        <button class="btn btn-outline-primary"
+                                            title="{{ 'button.call_next'|trans }}"
+                                            v-bind:disabled="busy || fila.atendimentos.length===0 || atendimento"
+                                            v-on:click="chamarServico(fila.servico.servico)"
+                                            v-if="fila.servico">
+                                            <i class="fa fa-bullhorn"></i>
+                                            {{ 'button.call'|trans }}
+                                        </button>
+                                    {% endif %}
+                                </li>
+                                <li v-for="(atendimento, index) in fila.atendimentos">
+                                    <a href="#"
+                                    v-bind:class="{ prioridade: atendimento.prioridade.peso, proximo: index===0 }"
+                                    v-bind:style="getItemFilaStyle(atendimento)"
+                                    v-on:click.prevent="infoSenha(atendimento)"
+                                    v-bind:title="atendimento.servico.nome + ' (' + atendimento.tempoEspera + ')'">
+                                        {%- verbatim -%}
+                                            <span>{{ getAtendimentoLabel(atendimento) }}</span>
+                                        {%- endverbatim -%}
+                                    </a>
+                                </li>
+                                <li class="empty" v-if="fila.atendimentos.length===0">
+                                    {{ 'label.my_queue.empty'|trans }}
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -722,21 +725,20 @@
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title">{% trans %}Configuração{% endtrans %}</h5>
+                        <h5 class="modal-title">{{ 'label.configuration'|trans }}</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <div class="row">
                             <div class="col-sm-12">
-                                <fieldset>
-                                    <legend>{% trans %}Fila de Senhas{% endtrans %}</legend>
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" v-model="config.exibirNomeCliente" v-on:change="saveConfig"> 
-                                            {% trans %}Exibir nome do cliente{% endtrans %}
-                                        </label>
-                                    </div>
-                                </fieldset>
+                                <div class="mb-3">
+                                    <label>{{ 'label.configuration.select_display_format_label'|trans }}</label>
+                                    <select class="form-select" v-on:change="saveConfig" v-model="config.formatoExibicaoFila">
+                                        <option value="ticket" selected>{{ 'label.configuration.option_ticket'|trans }}</option>
+                                        <option value="client_name">{{ 'label.configuration.option_client_name'|trans }}</option>
+                                        <option value="ticket_client_name">{{ 'label.configuration.option_ticket_client_name'|trans }}</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Olá!

Devido à necessidade de visualizar o nome do cliente na lista de senhas, resolvemos ajudar com uma pequena implementação.

Criamos um modal de configuração semelhante ao que existe no `triage-bundle`, onde adicionamos a configuração "Exibir nome do cliente" (checkbox).

Quando essa configuração é verdadeira, duas coisas acontecem:

1. A lista de senhas passa a ser exibida em lista (`display: block`).
2. As senhas que possuem um cliente vinculado exibirão o nome do mesmo ao lado da senha.
Esse ajuste é útil quando, no atendimento, o nome é importante para identificar o cliente.

Agradeço a revisão e estou à disposição para quaisquer ajustes técnicos necessários para a aprovação desta PR.

Cordialmente,
William Sampaio

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bd9bbfd5-8d60-4156-8c85-2391ef7c9b04" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/33e98349-4718-499e-8066-d0c77b02b21d" />

